### PR TITLE
File sending

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -51,7 +51,7 @@ ipcMain.handle('send-file', async (event, arg: string) => {
   fs.readFile(filepath, { encoding: 'base64' }, (err, fileContent) => {
     const filename = path.basename(filepath);
     const message: SendableMessage = {
-      type: 'message',
+      type: 'file',
       data: { filename, fileContent },
     };
     node.broadcast(message);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,10 +13,12 @@ import { app, BrowserWindow, shell, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import os from 'os';
+import fs from 'fs';
 import MenuBuilder from './menu';
 import { resolveHtmlPath } from './util';
 import createNode from './node';
 import prisma from './prisma';
+import { SendableMessage } from './types';
 
 class AppUpdater {
   constructor() {
@@ -46,7 +48,14 @@ ipcMain.on('ipc-example', async (event, arg) => {
 
 ipcMain.handle('send-file', async (event, arg: string) => {
   const filepath = arg;
-  console.log(filepath);
+  fs.readFile(filepath, { encoding: 'base64' }, (err, fileContent) => {
+    const filename = path.basename(filepath);
+    const message: SendableMessage = {
+      type: 'message',
+      data: { filename, fileContent },
+    };
+    node.broadcast(message);
+  });
 });
 
 ipcMain.handle('listen', async (event, ...args) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -44,6 +44,11 @@ ipcMain.on('ipc-example', async (event, arg) => {
   event.reply('ipc-example', msgTemplate('pong'));
 });
 
+ipcMain.handle('send-file', async (event, arg: string) => {
+  const filepath = arg;
+  console.log(filepath);
+});
+
 ipcMain.handle('listen', async (event, ...args) => {
   const msg = {
     event: 'listen',

--- a/src/main/node/index.ts
+++ b/src/main/node/index.ts
@@ -1,6 +1,8 @@
 import { nanoid } from 'nanoid';
 import { Socket, createServer } from 'net';
 import { EventEmitter } from 'events';
+import os from 'os';
+import fs from 'fs';
 import messageStream from './messageStream';
 import { MessageEvent, Packet, SendableMessage } from '../types';
 
@@ -142,6 +144,20 @@ const Server = () => {
   });
 
   /**
+   * Save a file to the user's Documents folder
+   * @param filename Name of file to save
+   * @param fileContent Base64-encoded file content to save
+   */
+  const saveFile = (filename: string, fileContent: string) => {
+    const saveFolder = `${os.homedir()}/Documents/`;
+    const savePath = saveFolder + filename;
+    fs.writeFile(savePath, fileContent, { encoding: 'base64' }, (err) => {
+      if (err) return console.log(err);
+      return console.log('File saved');
+    });
+  };
+
+  /**
    * On message received, check type of message and continue accordingly
    */
   emitter.on('_message', ({ connectionId, message }: MessageEvent) => {
@@ -162,6 +178,12 @@ const Server = () => {
       // TODO: handle no nodeId
 
       emitter.emit('message', { nodeId, data });
+    }
+
+    // For files
+    if (type === 'file') {
+      const { filename, fileContent } = data;
+      saveFile(filename, fileContent);
     }
   });
 

--- a/src/renderer/pages/Explorer.tsx
+++ b/src/renderer/pages/Explorer.tsx
@@ -1,8 +1,40 @@
+import { useState } from 'react';
+
 function Explorer() {
+  const [selectedFile, setSelectedFile] = useState<File>();
   return (
-    <div className="space-y-4">
-      <h1 className="font-extrabold text-xl text-zinc-50">File Explorer</h1>
-    </div>
+    <>
+      <div className="space-y-4">
+        <h1 className="font-extrabold text-xl text-zinc-50">File Explorer</h1>
+      </div>
+      <label htmlFor="out-file" className="text-white">
+        File to send
+        <br />
+        <input
+          type="file"
+          id="out-file"
+          name="out-file"
+          onChange={(e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+            setSelectedFile(file);
+          }}
+        />
+      </label>
+      <br />
+      <br />
+      <input
+        type="button"
+        id="send-button"
+        name="send-button"
+        value="Send File"
+        className="text-white bg-blue-500"
+        onClick={() => {
+          if (selectedFile === undefined) return;
+          window.electron.ipcRenderer.invoke('send-file', selectedFile.path);
+        }}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
* This should add a feature where you can send files to connected peers, and the files get saved in the peers' Documents folders
* Added a file selector and send button (in screenshot below)
* If you select a file and press the button, it'll call the broadcast method with the file's name and bsae64-encoded content in the message (tested)
* Added a function to decode file content and save to the user's Documents folder (tested)
* Server now checks for packets of type "file" and calls the file saving function (NOT TESTED)
* If this works, it'll only work for very SMALL files. If you try to send a large file it'll automatically break the message into multiple packets, and the server doesn't know how to handle that right now.
<img width="716" alt="Screenshot 2023-04-22 at 7 58 23 PM" src="https://user-images.githubusercontent.com/53921230/233812373-6ab06707-20d0-4636-b348-2370191212a0.png">
